### PR TITLE
Add "ios-" to the plugin name

### DIFF
--- a/MUXSDKStatsJWPlayer/MUXSDKStatsJWPlayer/MUXSDKStatsBinding.m
+++ b/MUXSDKStatsJWPlayer/MUXSDKStatsJWPlayer/MUXSDKStatsBinding.m
@@ -14,7 +14,7 @@
 
 @import MuxCore;
 
-NSString * const MUXSDKStatsKPluginName = @"jwplayer-mux";
+NSString * const MUXSDKStatsKPluginName = @"ios-jwplayer-mux";
 NSString * const MUXSDKStatsPluginVersion = @"0.1.0";
 
 typedef enum : NSUInteger {


### PR DESCRIPTION
Add "ios-" to the plugin name to differentiate this iOS SDK from the web SDK version